### PR TITLE
Segment boxes file loading check for stability

### DIFF
--- a/webfe/CrossValidation_HbbTV_DVB.php
+++ b/webfe/CrossValidation_HbbTV_DVB.php
@@ -35,11 +35,13 @@ function common_crossValidation($dom,$hbbtv,$dvb)
             for($d=$r+1; $d<$filecount; $d++){
                 $xml_d = xmlFileLoad($files[$d]);
                 
-                if($hbbtv){
-                    crossValidation_HbbTV_Representations($dom, $opfile, $xml_r, $xml_d, $adapt_count, $r, $d);
-                }
-                if($dvb){
-                    crossValidation_DVB_Representations($dom, $opfile, $xml_r, $xml_d, $adapt_count, $r, $d);
+                if($xml_r != 0 && $xml_d != 0){
+                    if($hbbtv){
+                        crossValidation_HbbTV_Representations($dom, $opfile, $xml_r, $xml_d, $adapt_count, $r, $d);
+                    }
+                    if($dvb){
+                        crossValidation_DVB_Representations($dom, $opfile, $xml_r, $xml_d, $adapt_count, $r, $d);
+                    }
                 }
             }
         }
@@ -504,23 +506,23 @@ function common_validation($dom,$hbbtv,$dvb, $sizearray,$bandwidth, $pstart){
     }
     
     $xml_rep = xmlFileLoad($locate.'/Adapt'.$count1.'/Adapt'.$count1.'rep'.$count2.'.xml');
+    if($xml_rep != 0){
+        if($dvb){
+            common_validation_DVB($opfile, $dom, $xml_rep, $count1, $count2, $sizearray);
+        }
+        if($hbbtv){
+            common_validation_HbbTV($opfile, $dom, $xml_rep, $count1, $count2);
+        } 
+        seg_timing_common($opfile, $xml_rep, $dom, $pstart);
+        
+        //seg_bitrate_common($opfile,$xml_rep);
+        bitrate_report($opfile, $dom, $xml_rep, $count1, $count2, $sizearray,$bandwidth);
 
-    if($dvb){
-        common_validation_DVB($opfile, $dom, $xml_rep, $count1, $count2, $sizearray);
-    }
-    if($hbbtv){
-        common_validation_HbbTV($opfile, $dom, $xml_rep, $count1, $count2);
-    } 
-    seg_timing_common($opfile, $xml_rep, $dom, $pstart);
-
-     //seg_bitrate_common($opfile,$xml_rep);
-     bitrate_report($opfile, $dom, $xml_rep, $count1, $count2, $sizearray,$bandwidth);
-
-
-    if ($presentationduration !== "") {
-        $checks = segmentToPeriodDurationCheck($xml_rep);
-        if(!$checks[0]){
-            fwrite($opfile, "###'HbbTV/DVB check violated: The accumulated duration of the segments [".$checks[1]. "seconds] in the representation does not match the period duration[".$checks[2]."seconds].\n'");
+        if ($presentationduration !== "") {
+            $checks = segmentToPeriodDurationCheck($xml_rep);
+            if(!$checks[0]){
+                fwrite($opfile, "###'HbbTV/DVB check violated: The accumulated duration of the segments [".$checks[1]. "seconds] in the representation does not match the period duration[".$checks[2]."seconds].\n'");
+            }
         }
     }
     /*$stats = getSegmentStats($xml_rep);
@@ -1031,10 +1033,11 @@ function init_seg_commonCheck($files,$opfile)
     for($i=0;$i<$rep_count;$i++)
     {
         $xml = xmlFileLoad($files[$i]);
-        $avcC_count=$xml->getElementsByTagName('avcC')->length;
-        fwrite($opfile, ", ".$avcC_count." 'avcC' in Representation ".($i+1)." \n");
+        if($xml != 0){
+            $avcC_count=$xml->getElementsByTagName('avcC')->length;
+            fwrite($opfile, ", ".$avcC_count." 'avcC' in Representation ".($i+1)." \n");
+        }
     }
-
 }
 
 function seg_timing_common($opfile,$xml_rep, $dom, $pstart)

--- a/webfe/compare.php
+++ b/webfe/compare.php
@@ -336,14 +336,17 @@ function compareRepresentations(){
 function xmlFileLoad($filename)
 {
     $load = simplexml_load_file($filename); // load mpd from url 
-    $dom_abs = dom_import_simplexml($load);
-    $abs = new DOMDocument('1.0');
-    $dom_abs = $abs->importNode($dom_abs, true); //create dom element to contain mpd 
+    if($load !== FALSE){
+        $dom_abs = dom_import_simplexml($load);
+        $abs = new DOMDocument('1.0');
+        $dom_abs = $abs->importNode($dom_abs, true); //create dom element to contain mpd 
             
-    $dom_abs = $abs->appendChild($dom_abs);
-            
-    $xml_atomlist = $abs->getElementsByTagName('atomlist')->item(0);
-    return $xml_atomlist;
+        $dom_abs = $abs->appendChild($dom_abs);
+        
+        $xml_atomlist = $abs->getElementsByTagName('atomlist')->item(0);
+        return $xml_atomlist;
+    }
+    return 0;
 }
 
 function getNALArray($hvcC, $type){


### PR DESCRIPTION
Sometimes the segment boxes file is empty or not compatible with XML syntax because of unknown characters. To avoid crashing of the software, the existence and the compatibility of these files need to be checked before further processing. This PR provides the mentioned fix.