### PR TITLE
Subtitle robustness

### DIFF
--- a/webfe/CrossValidation_HbbTV_DVB.php
+++ b/webfe/CrossValidation_HbbTV_DVB.php
@@ -651,7 +651,7 @@ function common_validation_DVB($opfile, $dom, $xml_rep, $adapt_count, $rep_count
     if(strpos($profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') !== FALSE){
         if($xml_rep->getElementsByTagName('sidx')->length != 1)
             fwrite($opfile, "###'DVB check violated: 'Segment includes features that are not required by the profile being validated against', found ". $xml_rep->getElementsByTagName('sidx')->length ." sidx boxes while according to Section 4.3 \"(For On Demand profile) The segment SHALL contain only one single Segment Index box ('sidx) for the entire segment\"'.\n");
-        if(count(glob($locate.'/Adapt'.$adapt_count.'rep'.$rep_count.'/*')) != 1)
+        if(count(glob($locate.'/Adapt'.$adapt_count.'rep'.$rep_count.'/*')) - count(glob($locate.'/Adapt'.$adapt_count.'rep'.$rep_count.'/*', GLOB_ONLYDIR)) != 1)
             fwrite($opfile, "###'DVB check violated: Section 4.3- (For On Demand profile) Each Representation SHALL have only one Segment', found more.\n");
     }
     

--- a/webfe/datadownload.php
+++ b/webfe/datadownload.php
@@ -102,7 +102,7 @@ function downloaddata($directory, $array_file, $subtitle_rep)
                         ## For DVB subtitle checks related to mdat content
                         ## Save the mdat boxes' content into xml files
                         if($subtitle_rep){
-                            $mdat_file = $directory . $mdat_index . '.xml';
+                            $mdat_file = $directory . 'Subtitles/' . $mdat_index . '.xml';
                             fopen($mdat_file, 'w');
                             chmod($mdat_file, 0777);
                             $mdat_index++;

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -847,16 +847,31 @@ function process_mpd()
             $subtitle_rep = false;
             $adapt = $periodNode->getElementsByTagName('AdaptationSet')->item($count1);
             $rep = $adapt->getElementsByTagName('Representation')->item($count2);
-            if(strpos($adapt->getAttribute('mimeType'), 'application') || $adapt->getAttribute('contentType') == 'text' || $adapt->getAttribute('codecs') == 'stpp'){
-                $subtitle_rep = true;
-            }
-            if(strpos($rep->getAttribute('mimeType'), 'application') || $rep->getAttribute('codecs') == 'stpp'){
-                $subtitle_rep = true;
-            }
-            if($adapt->getElementsByTagName('ContentComponent')->length != 0){
-                $contComp = $adapt->getElementsByTagName('ContentComponent')->item(0);
-                if($contComp->getAttribute('contentType') == 'text')
+            
+            if((strpos($adapt->getAttribute('mimeType'), 'application') != FALSE || strpos($rep->getAttribute('mimeType'), 'application') !== FALSE) &&
+               ($adapt->getAttribute('codecs') == 'stpp' || $rep->getAttribute('codecs') == 'stpp')){
+                
+                $contType = $adapt->getAttribute('contentType');
+                if($contType == ''){
+                    if($adapt->getElementsByTagName('ContentComponent')->length != 0){
+                        $contComp = $adapt->getElementsByTagName('ContentComponent')->item(0);
+                        if($contComp->getAttribute('contentType') == 'text')
+                            $subtitle_rep = true;
+                    }
+                    else
+                        $subtitle_rep = true;
+                }
+                elseif($contType == 'text')
                     $subtitle_rep = true;
+            }
+            
+            if($subtitle_rep){
+                $subtitle_dir = $pathdir . 'Subtitles/';
+                if (!file_exists($subtitle_dir)){
+                    $oldmask = umask(0);
+                    mkdir($subtitle_dir, 0777, true);
+                    umask($oldmask);
+                }
             }
             ##
             


### PR DESCRIPTION
- DVB subtitle mdat boxes are saved into xml files only if they are signalled in the MPD as compliant with EBU-TT-D subtitles (mimetype = 'application/*' and codecs = 'stpp')
- Since in such a case the mdats are saved in the same directory as the segments, the segment count checks for on-demand/live profiles could be affected. To avoid this:
       - xml files are saved in "Subtitles" directory inside the segment directory.
       - The counting checks are updated to exclude the subdirectories