### PR TITLE
Subtitle timing

### DIFF
--- a/webfe/MPD_HbbTV_DVB.php
+++ b/webfe/MPD_HbbTV_DVB.php
@@ -793,9 +793,7 @@ function StreamBandwidthCheck($mpdreport){
 
 function DVB_event_checks($possible_event, $mpdreport){
     global $period_count;
-    if($possible_event->getAttribute('schemeIdUri') != 'urn:dvb:iptv:cpm:2014')
-        fwrite($mpdreport, "###'DVB check violated: Section 9.1.2.1- The @schemeIdUri attribute (of EventStream) SHALL be set to \"urn:dvb:iptv:cpm:2014\"', not set accordingly in Period $period_count.\n");
-    else{
+    if($possible_event->getAttribute('schemeIdUri') != 'urn:dvb:iptv:cpm:2014'){
         if($possible_event->getAttribute('value') == '1'){
             $events = $possible_event->getElementsByTagName('Event');
             foreach ($events as $event){

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -851,7 +851,7 @@ function process_mpd()
             $adapt = $periodNode->getElementsByTagName('AdaptationSet')->item($count1);
             $rep = $adapt->getElementsByTagName('Representation')->item($count2);
             
-            if((strpos($adapt->getAttribute('mimeType'), 'application') != FALSE || strpos($rep->getAttribute('mimeType'), 'application') !== FALSE) &&
+            if(($adapt->getAttribute('mimeType') == 'application/mp4' || $rep->getAttribute('mimeType') == 'application/mp4') &&
                ($adapt->getAttribute('codecs') == 'stpp' || $rep->getAttribute('codecs') == 'stpp')){
                 
                 $contType = $adapt->getAttribute('contentType');
@@ -1123,7 +1123,8 @@ function process_mpd()
                // }
                 
                 if($check_dvb_conformance || $check_hbbtv_conformance){
-                    common_validation($dom,$check_hbbtv_conformance,$check_dvb_conformance, $sizearray,$Period_arr[$count1]['Representation']['bandwidth'][$count2], $start);
+                    $media_types = media_types($periodNode);
+                    common_validation($dom,$check_hbbtv_conformance,$check_dvb_conformance, $sizearray,$Period_arr[$count1]['Representation']['bandwidth'][$count2], $start, $media_types);
                     $copy_string_info=$string_info;
                     $index = strpos($copy_string_info, '</body>');
                     


### PR DESCRIPTION
Subtitle checks corresponding to EBU-TT-D documents
- Check that subtitle segments contain ISO BMFF packaged EBU-TT-D.
- Check that timings of subtitles in a segment are relative to the start of the stream.
- Check the ISO BMFF is according to EBU TECH 3381 at a simple level. 