### PR TITLE
Small extension for cross validation reporting on UI

### DIFF
--- a/webfe/CrossValidation_HbbTV_DVB.php
+++ b/webfe/CrossValidation_HbbTV_DVB.php
@@ -54,7 +54,6 @@ function common_crossValidation($dom,$hbbtv,$dvb)
        
         }
         
-        fprintf($opfile, "\n-----Conformance checks completed----- ");
         fclose($opfile);
         $temp_string = str_replace (array('$Template$'),array("Adapt".$adapt_count."_compInfo"),$string_info);
         file_put_contents($locate.'/'."Adapt".$adapt_count."_compInfo.html",$temp_string);
@@ -1469,7 +1468,6 @@ function content_protection_report($dom_MPD)
         $adaptreport = fopen($locate . "/Adapt".$Adapt_index."_compInfo.txt", 'a+b');
         if($adaptreport !== false)
         {
-            fwrite($adaptreport, "***Report on Content Protection specifics*** \n");
             $MPD_systemID_array = array();
             $missing_pssh_array = array(); //holds the uuid-s of the DRM-s which are missing the pssh in the mpd
             $reps_array = array(); // for the summary of reps and their KID
@@ -1704,7 +1702,6 @@ function content_protection_report($dom_MPD)
                 fwrite($adaptreport, "Information on DVB/HbbTV: Content Protection not used in Adaptation Set ".$adapt_id.".\n");
             }
 
-            fwrite($adaptreport, "-------------------------------------------------------------------------------------------- \n");
             fclose($adaptreport);
         }    
         $Adapt_index ++; //move to check the next adapt set
@@ -2108,7 +2105,7 @@ function seg_duration_checks($dom_MPD, $count1, $count2, $opfile)
                     {
                         if($handler_type == 'vide')
                         {
-                            fwrite($opfile, "###WARNING on DVB/HbbTV: The fragment duration of video type (".$fragment_duration_sec." sec) is different from the sum of all segment durations (".$total_seg_duration." sec) in Adaptation Set: "
+                            fwrite($opfile, "WARNING on DVB/HbbTV: The fragment duration of video type (".$fragment_duration_sec." sec) is different from the sum of all segment durations (".$total_seg_duration." sec) in Adaptation Set: "
                                     .$adapt_id." Representation with 'id' : ".$rep_id. ".\n");
                         }
                         elseif($handler_type == 'soun')

--- a/webfe/conformancetest.php
+++ b/webfe/conformancetest.php
@@ -939,16 +939,12 @@ function progress()  //Progress of Segments' Conformance
                 for(var i =1; i<=ComparedRepresentations.length;i++)
                 {
                     if(ComparedRepresentations[i-1].textContent=="noerror"){
-                        tree.setItemImage2(adaptid[i-1],'right.jpg','right.jpg','right.jpg');
                         automate(adaptid[i-1],lastloc,"DVB-HbbTV Compared representations validation success");
-                        
                         tree.setItemImage2(lastloc,'right.jpg','right.jpg','right.jpg');
                         lastloc++;
                     }
                     else if(ComparedRepresentations[i-1].textContent=="warning"){
-                        tree.setItemImage2(adaptid[i-1],'right.jpg','right.jpg','right.jpg');
                         automate(adaptid[i-1],lastloc,"DVB-HbbTV Compared representations validation warning");
-                        
                         tree.setItemImage2(lastloc,'log.jpg','log.jpg','log.jpg');
                         lastloc++;
                         
@@ -959,9 +955,7 @@ function progress()  //Progress of Segments' Conformance
                         lastloc++;
                     }
                     else{
-                        tree.setItemImage2(adaptid[i-1],'button_cancel.png','button_cancel.png','button_cancel.png');
                         automate(adaptid[i-1],lastloc,"DVB-HbbTV Compared representations validation error");
-                        
                         tree.setItemImage2(lastloc,'button_cancel.png','button_cancel.png','button_cancel.png');
                         lastloc++;
                         

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -755,11 +755,11 @@ function process_mpd()
                 
                 if(($check_dvb_conformance || $check_hbbtv_conformance) && file_exists($locate . '/Adapt' . $i . '_compInfo.txt')){
                     $searchfiles = file_get_contents($locate . '/Adapt' . $i . '_compInfo.txt');
-                    if(strpos($searchfiles, "DVB check violated") !== FALSE || strpos($searchfiles, "HbbTV check violated") !== FALSE){
+                    if(strpos($searchfiles, "DVB check violated") !== FALSE || strpos($searchfiles, "HbbTV check violated") !== FALSE || strpos($searchfiles, 'ERROR') !== FALSE){
                         $ResultXML->Period[0]->Adaptation[$i]->addChild('ComparedRepresentations', 'error');
                         $file_error[] = $locate.'/Adapt'.$i.'_compInfo.html'; // add error file location to array
                     }
-                    elseif(strpos($searchfiles, "Warning") !== FALSE){
+                    elseif(strpos($searchfiles, "Warning") !== FALSE || strpos($searchfiles, "WARNING") !== FALSE){
                         $ResultXML->Period[0]->Adaptation[$i]->addChild('ComparedRepresentations', 'warning');
                         $file_error[] = $locate.'/Adapt'.$i.'_compInfo.html'; // add error file location to array
                     }


### PR DESCRIPTION
Some message logs was containing non-compliant beginnings for UI reporting, such as ERROR and ###WARNING. Necessary changes have been made to make the colored UI reporting in cross validation checks possible.