### PR TITLE
Content protection flag is now working

### DIFF
--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -937,9 +937,17 @@ function process_mpd()
                     $dash264 = true;
                 }
 
-                if ($Period_arr[$count1]['Representation']['ContentProtectionElementCount'][$count2] > 0 && $dash264 == true)
-                {
-                    $processArguments = $processArguments . "-dash264enc ";
+                if($check_dvb_conformance || $check_hbbtv_conformance){
+                    if ($Period_arr[$count1]['Representation']['ContentProtectionElementCount'][$count2] > 0)
+                    {
+                        $processArguments = $processArguments . "-dash264enc ";
+                    }
+                }
+                else{
+                    if ($Period_arr[$count1]['Representation']['ContentProtectionElementCount'][$count2] > 0 && $dash264 == true)
+                    {
+                        $processArguments = $processArguments . "-dash264enc ";
+                    }
                 }
 
                 $processArguments = $processArguments . "-codecs ";


### PR DESCRIPTION
There is no clear indication on the compulsory check for dash-avc/264 profile along with content protection. But rather than removing it, it is disabled for dvb/hbbtv checks.