### PR TITLE
Checkbox made optional and MPD profile is checked before processing

### DIFF
--- a/webfe/CrossValidation_HbbTV_DVB.php
+++ b/webfe/CrossValidation_HbbTV_DVB.php
@@ -766,7 +766,7 @@ function common_validation_DVB($opfile, $dom, $xml_rep, $adapt_count, $rep_count
     ## Segment checks
     $moof_boxes = $xml_rep->getElementsByTagName('moof');
     // Section 4.3 on on-demand profile periods containing sidx boxes
-    if(strpos($profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') !== FALSE){
+    if(strpos($profiles, 'urn:mpeg:dash:profile:isoff-on-demand:2011') !== FALSE || strpos($profiles, 'urn:dvb:dash:profile:dvb-dash:isoff-ext-on-demand:2014') !== FALSE){
         if($xml_rep->getElementsByTagName('sidx')->length != 1)
             fwrite($opfile, "###'DVB check violated: 'Segment includes features that are not required by the profile being validated against', found ". $xml_rep->getElementsByTagName('sidx')->length ." sidx boxes while according to Section 4.3 \"(For On Demand profile) The segment SHALL contain only one single Segment Index box ('sidx) for the entire segment\"'.\n");
         if(count(glob($locate.'/Adapt'.$adapt_count.'rep'.$rep_count.'/*')) - count(glob($locate.'/Adapt'.$adapt_count.'rep'.$rep_count.'/*', GLOB_ONLYDIR)) != 1)

--- a/webfe/MPD_HbbTV_DVB.php
+++ b/webfe/MPD_HbbTV_DVB.php
@@ -58,9 +58,15 @@ function HbbTV_DVB_mpdvalidator($dom, $hbbtv, $dvb) {
 }
 
 function DVB_HbbTV_profile_specific_media_types_report($dom, $mpdreport){
+    global $enforced_profile_dvb, $enforced_profile_hbbtv;
     
     $MPD = $dom->getElementsByTagName('MPD')->item(0);
     $mpd_profiles = $MPD->getAttribute('profiles');
+    
+    if($enforced_profile_dvb)
+        $mpd_profiles .= ',urn:dvb:dash:profile:dvb-dash:2014';
+    if($enforced_profile_hbbtv)
+        $mpd_profiles .= ',urn:hbbtv:dash:profile:isoff-live:2012';
     
     $profiles_arr = explode(',', $mpd_profiles);
     if(sizeof($profiles_arr) > 1){

--- a/webfe/conformancetest.php
+++ b/webfe/conformancetest.php
@@ -299,7 +299,7 @@
         <p class="sansserif"><input type="checkbox" id="mpdvalidation" class = "validation" value="0">MPD conformance only</p><br>
     </form>
     <div class="profiles">
-            Select profile(s): <input type="checkbox" class="profile1" id="dvbprofile">
+            Enforce profile(s): <input type="checkbox" class="profile1" id="dvbprofile">
                                     <label for="dvbprofile">DVB</label>
                                <input type="checkbox" class="profile2" id="hbbtvprofile">
                                     <label for="hbbtvprofile">HbbTV</label>
@@ -360,7 +360,8 @@ var progressSegmentsTimer;
 var pollingTimer;
 var ChainedToUrl;
 var cmaf = "<?php echo $cmaf; ?>";
-
+var dvb = 0;
+var hbbtv = 0;
 
 /////////////////////////////////////////////////////////////
 //Check if 'drag and drop' feature is supported by the browser, if not, then traditional file upload can be used.
@@ -752,8 +753,11 @@ function processmpdresults(MPDtotalResultXML)
     }
     totarr.splice(0,1);
     x++;
-    if($("#dvbprofile").is(':checked') || $("#hbbtvprofile").is(':checked'))
+    if($("#dvbprofile").is(':checked') || $("#hbbtvprofile").is(':checked') || (totarr !== undefined && totarr.length != 0 && totarr[0] != ''))
     {
+        dvb = 1;
+        hbbtv = 1;
+        
         if(totarr[0]==='true') // New for HbbTV-DVB conformance.
         {
             automate(y,x,"HbbTv DVB validation");
@@ -943,7 +947,7 @@ function progress()  //Progress of Segments' Conformance
             }
         }
         
-        if($("#dvbprofile").is(':checked') || $("#hbbtvprofile").is(':checked')){
+        if($("#dvbprofile").is(':checked') || $("#hbbtvprofile").is(':checked') || dvb == 1 || hbbtv == 1){
             if(ComparedRepresentations.length!=0 && adaptationid>totarr[0]){
                 for(var i =1; i<=ComparedRepresentations.length;i++)
                 {

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -16,7 +16,7 @@
 
 function process_mpd()
 {
-    global $Adapt_arr, $Period_arr, $repno, $repnolist, $period_url, $locate, $string_info
+    global $Adapt_arr, $Period_arr, $repno, $repnolist, $period_url, $locate, $string_info, $enforced_profile_dvb, $enforced_profile_hbbtv
     , $presentationduration, $count1, $count2, $perioddepth, $adaptsetdepth, $period_baseurl, $foldername, $type, $minBufferTime, $profiles, $MPD, $session_id, $progressXML; //Global variables to be used within the main function
     //  $path_parts = pathinfo($mpdurl); 
     $Baseurl = false; //define if Baseurl is used or no
@@ -106,18 +106,10 @@ function process_mpd()
 
     $url_array[3] = $locate; //Used for e.g. placing intermediate files etc.
     $cmaf_val = $url_array[4];     
-    $check_dvb_conformance = $url_array[5];
-    $check_hbbtv_conformance = $url_array[6];
+    $enforced_profile_dvb = $url_array[5];
+    $enforced_profile_hbbtv = $url_array[6];
     //The status of the mpd is logged in the visitor's log file.
     writeMPDStatus($url_array[0]);
-    
-    copy(dirname(__FILE__) . "/" . "featuretable.html", $locate . '/' . "featuretable.html"); // copy features list html file to session folder
-    if($check_dvb_conformance || $check_hbbtv_conformance){
-        copy(dirname(__FILE__) . "/bitratereport.py", $locate . '/bitratereport.py'); // copy conformance tool to session folder to allow multi-session operation
-        chmod($locate . '/bitratereport.py', 0777);
-        copy(dirname(__FILE__) . "/seg_duration.py", $locate . '/seg_duration.py'); // copy conformance tool to session folder to allow multi-session operation
-        chmod($locate . '/seg_duration.py', 0777);
-    }
     
     //Create log file so that it is available if accessed
     $progressXML = simplexml_load_string('<root><Profile></Profile><Progress><percent>0</percent><dataProcessed>0</dataProcessed><dataDownloaded>0</dataDownloaded><CurrentAdapt>1</CurrentAdapt><CurrentRep>1</CurrentRep></Progress><completed>false</completed></root>'); // get progress bar update
@@ -146,12 +138,46 @@ function process_mpd()
         exit;
     }
     
+    ## First determine if DVB and/or HbbTV profiles exist in the provided MPD file
+    ## If yes, then the MPD and media segments shall be validated against the profile(s)
+    $check_dvb_conformance = 0;
+    $check_hbbtv_conformance = 0;
+    $preliminary_dom_doc = new DOMDocument('1.0');
+    $preliminary_dom_sxe = $preliminary_dom_doc->importNode($dom_sxe, true);
+    $preliminary_dom_doc->appendChild($preliminary_dom_sxe);
+    $MPD_nodes = $preliminary_dom_doc->getElementsByTagName('MPD');
+    if($MPD_nodes->length != 0){
+        $MPD_node = $MPD_nodes->item(0);
+        $MPD_profiles = $MPD_node->getAttribute('profiles');
+        if(strpos($MPD_profiles, 'urn:dvb:dash:profile:dvb-dash:2014') !== FALSE || strpos($MPD_profiles, 'urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014')!== FALSE || strpos($MPD_profiles, 'urn:dvb:dash:profile:dvb-dash:isoff-ext-on-demand:2014') !== FALSE)
+            $check_dvb_conformance = 1;
+        if(strpos($MPD_profiles, 'urn:hbbtv:dash:profile:isoff-live:2012') !== FALSE)
+            $check_hbbtv_conformance = 1;
+    }
+    ##
+    
+    $dvb = 0;
+    $hbbtv = 0;
+    if($check_dvb_conformance || $enforced_profile_dvb)
+        $dvb = 1;
+    if($check_hbbtv_conformance || $enforced_profile_hbbtv)
+        $hbbtv = 1;
+    json_encode("DVB/HbbTV: $dvb $hbbtv");
+    
+    // To import DVB/HbbTV-related plotting functions into the created temporary session folder
+    if($dvb || $hbbtv){
+        copy(dirname(__FILE__) . "/bitratereport.py", $locate . '/bitratereport.py'); // copy conformance tool to session folder to allow multi-session operation
+        chmod($locate . '/bitratereport.py', 0777);
+        copy(dirname(__FILE__) . "/seg_duration.py", $locate . '/seg_duration.py'); // copy conformance tool to session folder to allow multi-session operation
+        chmod($locate . '/seg_duration.py', 0777);
+    }
+    
     //xlink_reconstruct_MPD($dom_sxe);
     global $cp_dom; // to have a dom document with the original unchanged mpd
     $cp_dom = new DOMDocument('1.0');
     $cp_dom_node = $cp_dom->importNode($dom_sxe, true);
     $cp_dom->appendChild($cp_dom_node);
-    if($check_dvb_conformance){
+    if($dvb){
         $mpdreport = fopen($locate . '/mpdreport.txt', 'a+b');
         $dom_doc = new DOMDocument('1.0');
         $dom_node = $dom_doc->importNode($dom_sxe, true);
@@ -191,19 +217,8 @@ function process_mpd()
     createMpdFeatureList($dom, $schematronIssuesReport);
     
     $mpd_profiles = $MPD->getAttribute('profiles');
-    if($check_hbbtv_conformance || $check_dvb_conformance){
-        if($check_dvb_conformance && strpos('urn:dvb:dash:profile:dvb-dash:2014', $mpd_profiles) === FALSE)
-            $mpd_profiles = $mpd_profiles . ',urn:dvb:dash:profile:dvb-dash:2014';
-        if($check_hbbtv_conformance && strpos('urn:hbbtv:dash:profile:isoff-live:2012', $mpd_profiles) === FALSE)
-            $mpd_profiles = $mpd_profiles . ',urn:hbbtv:dash:profile:isoff-live:2012';
-        
-        $MPD->removeAttribute('profiles');
-        $MPD->setAttribute('profiles', $mpd_profiles);
-        $dom = new DOMDocument('1.0');
-        $dom_sxe = $dom->importNode($MPD, true);
-        $dom->appendChild($dom_sxe);
-        
-        $result_hbbtvDvb=HbbTV_DVB_mpdvalidator($dom, $check_hbbtv_conformance, $check_dvb_conformance);
+    if($hbbtv || $dvb){
+        $result_hbbtvDvb=HbbTV_DVB_mpdvalidator($dom, $hbbtv, $dvb);
         if($result_hbbtvDvb!=="")
             $temp_mpdres = $temp_mpdres . $result_hbbtvDvb;
     }
@@ -707,8 +722,8 @@ function process_mpd()
                 checkRepresentationsConformance();//Check after downloading all AdaptationSets.
                 checkSwitchingSets();
             }
-            if($check_hbbtv_conformance || $check_dvb_conformance){
-                CrossValidation_HbbTV_DVB($dom,$check_hbbtv_conformance,$check_dvb_conformance);
+            if($hbbtv || $dvb){
+                CrossValidation_HbbTV_DVB($dom,$hbbtv,$dvb);
             }
             crossRepresentationProcess();
             $missingexist = file_exists($locate . '/missinglink.txt'); //check if any broken urls is detected
@@ -753,7 +768,7 @@ function process_mpd()
                     $ResultXML->Period[0]->Adaptation[$i]->ComparedRepresentations->addAttribute('url', str_replace($_SERVER['DOCUMENT_ROOT'], 'http://' . $_SERVER['SERVER_NAME'], $locate.'/Adapt'.$i.'_compInfo.txt'));
                 }
                 
-                if(($check_dvb_conformance || $check_hbbtv_conformance) && file_exists($locate . '/Adapt' . $i . '_compInfo.txt')){
+                if(($dvb || $hbbtv) && file_exists($locate . '/Adapt' . $i . '_compInfo.txt')){
                     $searchfiles = file_get_contents($locate . '/Adapt' . $i . '_compInfo.txt');
                     if(strpos($searchfiles, "DVB check violated") !== FALSE || strpos($searchfiles, "HbbTV check violated") !== FALSE || strpos($searchfiles, 'ERROR') !== FALSE){
                         $ResultXML->Period[0]->Adaptation[$i]->addChild('ComparedRepresentations', 'error');
@@ -937,7 +952,7 @@ function process_mpd()
                     $dash264 = true;
                 }
 
-                if($check_dvb_conformance || $check_hbbtv_conformance){
+                if($dvb || $hbbtv){
                     if ($Period_arr[$count1]['Representation']['ContentProtectionElementCount'][$count2] > 0)
                     {
                         $processArguments = $processArguments . "-dash264enc ";
@@ -1021,7 +1036,7 @@ function process_mpd()
                     }
                 }
                 
-                if($check_dvb_conformance || $check_hbbtv_conformance){
+                if($dvb || $hbbtv){
                     if($Period_arr[$count1]['frameRate'] === NULL)
                         $processArguments = $processArguments . " -framerate " . $Period_arr[$count1]['Representation']['frameRate'][$count2];
                     else
@@ -1063,13 +1078,13 @@ function process_mpd()
                         fwrite($config_file, $pie . "\n");
                 }
 
-                if($cmaf_val == "yes" || $check_dvb_conformance || $check_hbbtv_conformance){
+                if($cmaf_val == "yes" || $dvb || $hbbtv){
                     $command = $locate . '/' . $validatemp4 . " -atomxml";
                     if($cmaf_val == "yes")
                         $command = $command . " -cmaf";
-                    if($check_dvb_conformance)
+                    if($dvb)
                         $command = $command . " -dvb";
-                    if($check_hbbtv_conformance){
+                    if($hbbtv){
                         $command = $command . " -hbbtv";
                         if(strpos($processArguments, '-isolive') === FALSE)
                             fwrite($config_file, "-isolive\n");
@@ -1110,7 +1125,7 @@ function process_mpd()
                 
                 // Compare representations
                 //if($shouldCompare){
-                if($cmaf_val == "yes" || $check_dvb_conformance || $check_hbbtv_conformance){
+                if($cmaf_val == "yes" || $dvb || $hbbtv){
                     $new_pathdir = $locate . "/Adapt" . $count1;
                     if (!file_exists($new_pathdir)){
                         $oldmask = umask(0);
@@ -1132,9 +1147,9 @@ function process_mpd()
                //     unlink($locate . '/' . "atominfo.xml");
                // }
                 
-                if($check_dvb_conformance || $check_hbbtv_conformance){
+                if($dvb || $hbbtv){
                     $media_types = media_types($periodNode);
-                    common_validation($dom,$check_hbbtv_conformance,$check_dvb_conformance, $sizearray,$Period_arr[$count1]['Representation']['bandwidth'][$count2], $start, $media_types);
+                    common_validation($dom,$hbbtv,$dvb, $sizearray,$Period_arr[$count1]['Representation']['bandwidth'][$count2], $start, $media_types);
                     $copy_string_info=$string_info;
                     $index = strpos($copy_string_info, '</body>');
                     
@@ -1142,10 +1157,7 @@ function process_mpd()
                     $segemnet_duration_name = 'Adapt' . $count1 . '_rep' . $count2 . '.png';
                     $copy_string_info = substr($copy_string_info, 0, $index) ."<img id=\"bitrateReport\" src=\"$segemnet_duration_name\" width=\"650\" height=\"350\">".
                     "<img id=\"bitrateReport\" src=\"$bitrate_report_name\" width=\"650\" height=\"350\">" .substr($copy_string_info, $index);
-                    $temp_string = str_replace(array('$Template$'), array($repno . "log"), $copy_string_info); // this string shows a text file on HTML
-                    
-                    
-                    
+                    $temp_string = str_replace(array('$Template$'), array($repno . "log"), $copy_string_info);
                 }
                 else
                     $temp_string = str_replace(array('$Template$'), array($repno . "log"), $string_info); // this string shows a text file on HTML
@@ -1174,7 +1186,7 @@ function process_mpd()
                     $ResultXML->Period[0]->Adaptation[$tempcount1]->Representation[$count2 - 1] = "error";
                     $file_location[] = "error"; //else notify client with error
                 }
-                if($check_dvb_conformance || $check_hbbtv_conformance){
+                if($dvb || $hbbtv){
                     if (strpos($search, "###") === false){
                         if(strpos($search, "Warning") === false && strpos($search, "WARNING") === false){
                             $ResultXML->Period[0]->Adaptation[$tempcount1]->Representation[$count2 - 1] = "noerror";


### PR DESCRIPTION
The functioning of the tool is as follows:
- If the MPD contains any DVB or HbbTV profile, it shall be validated against that profile.
- If the checkbox is checked for DVB or HbbTV, it shall be validated against the checked profile **as well**.

The UI is changed to provide the log files by not only looking at checkbox status but also the MPD profile attribute.