### PR TITLE
Feature list fix for attributes with namespaces

### DIFF
--- a/webfe/featurlist.php
+++ b/webfe/featurlist.php
@@ -307,8 +307,8 @@ function setFeatureListEntry($node, $pathOfElement, $schematronIssuesReport)
             {
                 for ($i = 0; $i < $numbOfAttributes;  ++$i)
                 {
-                    $name = $node->attributes->item($i)->name;
-                    $value = $node->attributes->item($i)->value;
+                    $name = $node->attributes->item($i)->nodeName;
+                    $value = $node->attributes->item($i)->nodeValue;
 
                     if ($schemaIssues->text !== "false" and isAttributeWithSchemaIssues($name, $schemaIssues))
                     {

--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -111,6 +111,7 @@ function process_mpd()
     //The status of the mpd is logged in the visitor's log file.
     writeMPDStatus($url_array[0]);
     
+    copy(dirname(__FILE__) . "/" . "featuretable.html", $locate . '/' . "featuretable.html"); // copy features list html file to session folder
     //Create log file so that it is available if accessed
     $progressXML = simplexml_load_string('<root><Profile></Profile><Progress><percent>0</percent><dataProcessed>0</dataProcessed><dataDownloaded>0</dataDownloaded><CurrentAdapt>1</CurrentAdapt><CurrentRep>1</CurrentRep></Progress><completed>false</completed></root>'); // get progress bar update
     $progressXML->asXml($locate . '/progress.xml'); //progress xml location


### PR DESCRIPTION
In case of an attribute with namespace, the (DOMNode) node->name was returning the attribute name without the namespace, thus causing this attribute to be processed incorrectly (example screenshot for this is in the issue #152). 

This PR fixes this issue.  