### PR TITLE
dyhmtltree error fix

### DIFF
--- a/webfe/conformancetest.php
+++ b/webfe/conformancetest.php
@@ -29,8 +29,8 @@
     <!--link rel="stylesheet" href="/resources/demos/style.css" /-->
 
     <link rel="STYLESHEET" type="text/css" href="tree/dhtmlxTree/codebase/dhtmlxtree.css">
-    <script type="text/javascript"  src="tree/dhtmlxTree/codebase/dhtmlxtree.js"></script>
     <script type="text/javascript" src="tree/dhtmlxTree/codebase/dhtmlxcommon.js"></script>
+    <script type="text/javascript"  src="tree/dhtmlxTree/codebase/dhtmlxtree.js"></script>
     <script type="text/javascript" src="tree/dhtmlxTree/codebase/ext/dhtmlxtree_json.js"></script>
     
 <?php 


### PR DESCRIPTION
This error was not only in Firefox but also Chrome. Suggested fix in #156 is integrated to solve this. 