### PR TITLE
DVB accompanying profiles are considered for segment validation

### DIFF
--- a/webfe/mpdprocessing.php
+++ b/webfe/mpdprocessing.php
@@ -937,10 +937,10 @@ function process_mpd()
                 if ($Period_arr[$count1]['Representation']['startWithSAP'][$count2] != "")
                     $processArguments = $processArguments . "-startwithsap " . $Period_arr[$count1]['Representation']['startWithSAP'][$count2] . " ";
 
-                if (strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:mpeg:dash:profile:isoff-on-demand:2011") !== false)
+                if (strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:mpeg:dash:profile:isoff-on-demand:2011") !== false || strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:dvb:dash:profile:dvb-dash:isoff-ext-on-demand:2014") !== false)
                     $processArguments = $processArguments . "-isoondemand ";
 
-                if (strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:mpeg:dash:profile:isoff-live:2011") !== false)
+                if (strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:mpeg:dash:profile:isoff-live:2011") !== false || strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014") !== false)
                     $processArguments = $processArguments . "-isolive ";
 
                 if (strpos($Period_arr[$count1]['Representation']['profiles'][$count2], "urn:mpeg:dash:profile:isoff-main:2011") !== false)


### PR DESCRIPTION
In DVB specification Section 4.1, it is stated that “The DVB Profile of MPEG-DASH, known as an "interoperability point" by MPEG, is based on the merging of the ISO/IEC 23009-1 [1], ISO Base media file format live profile and ISO Base media file format On Demand profile”. 

Therefore, -isolive and -isoondemand flags are enabled for the respective DVB accompanying profiles. With this being enabled, supported profiles by the tool are also extended with these profiles. 